### PR TITLE
Render `script` and `shell` as literals, fix workspace-cleanup bug

### DIFF
--- a/jenkins_job_wrecker/job_handlers.py
+++ b/jenkins_job_wrecker/job_handlers.py
@@ -922,7 +922,7 @@ def handle_publishers(top):
                 post_tasks.append(post_task)
             publishers.append({'post-tasks': post_tasks})
         elif child.tag == 'hudson.plugins.ws__cleanup.WsCleanup':
-            cleanup = {'include': [], 'exclude': [], 'clean-if': {}}
+            cleanup = {'include': [], 'exclude': [], 'clean-if': []}
             for cleanupel in child:
                 if cleanupel.tag == 'patterns':
                     for pattern in cleanupel:
@@ -937,15 +937,15 @@ def handle_publishers(top):
                 elif cleanupel.tag == 'deleteDirs':
                     cleanup['dirmatch'] = get_bool(cleanupel.text)
                 elif cleanupel.tag == 'cleanWhenSuccess':
-                    cleanup['clean-if']['success'] = get_bool(cleanupel.text)
+                    cleanup['clean-if'].append({'success': get_bool(cleanupel.text)})
                 elif cleanupel.tag == 'cleanWhenUnstable':
-                    cleanup['clean-if']['unstable'] = get_bool(cleanupel.text)
+                    cleanup['clean-if'].append({'unstable': get_bool(cleanupel.text)})
                 elif cleanupel.tag == 'cleanWhenFailure':
-                    cleanup['clean-if']['failure'] = get_bool(cleanupel.text)
+                    cleanup['clean-if'].append({'failure': get_bool(cleanupel.text)})
                 elif cleanupel.tag == 'cleanWhenNotBuilt':
-                    cleanup['clean-if']['not-built'] = get_bool(cleanupel.text)
+                    cleanup['clean-if'].append({'not-built': get_bool(cleanupel.text)})
                 elif cleanupel.tag == 'cleanWhenAborted':
-                    cleanup['clean-if']['aborted'] = get_bool(cleanupel.text)
+                    cleanup['clean-if'].append({'aborted': get_bool(cleanupel.text)})
                 elif cleanupel.tag == 'notFailBuild':
                     cleanup['fail-build'] = not get_bool(cleanupel.text)
                 elif cleanupel.tag == 'cleanupMatrixParent':


### PR DESCRIPTION
To make the yaml more readable when it's using long
shell scripts, they should be rendered as literals.

This works for the majority of shell scripts, although
the yaml dump refuses to render some strings as literals
when they look like they should be fine. This isn't a bug
with wrecker, the data is going to the yaml dumper correctly,
but there's something in the string that the dumper doesn't
like

Also, fixed a small bug in the workspace-cleanup conversion.
The clean-if field should have been a list of dicts, not a dict.
This has been tested with our CI Jenkins instance, converting all
of our jobs to yaml, then back again to xml with notnownikki/jenkins-job-builder master,
which hs cherrypicks of certain plugins that we use that are still up
for review in gerrit.