### PR TITLE
Fix broken "convert all jobs on server" function

### DIFF
--- a/jenkins_job_wrecker/cli.py
+++ b/jenkins_job_wrecker/cli.py
@@ -213,8 +213,8 @@ def main():
             job_names = []
             for job in server.get_jobs():
 
-                if job['name'] in args.ignore:
-                    log.info('Ignoring [%s] as requested...' % job)
+                if args.ignore and job['name'] in args.ignore:
+                    log.info('Ignoring \"%s\" as requested...' % job['name'])
                     continue
 
                 job_names.append(job['name'])


### PR DESCRIPTION
This will resolve #18, casued by the list of ignored jobs being checked even
when the ignore argument had not been used.