### PR TITLE
setup.py: flake8 fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools.command.test import test as TestCommand
 
 version = '1.0.6'
 
+
 class PyTest(TestCommand):
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
 
@@ -18,10 +19,10 @@ class PyTest(TestCommand):
         self.test_suite = True
 
     def run_tests(self):
-        #import here, cause outside the eggs aren't loaded
         import pytest
         errno = pytest.main('tests', self.pytest_args)
         sys.exit(errno)
+
 
 class ReleaseCommand(Command):
     """ Tag and push a new release. """
@@ -62,7 +63,7 @@ setup(name="jenkins-job-wrecker",
                    'License :: OSI Approved :: MIT License',
                    'Operating System :: OS Independent',
                    'Programming Language :: Python',
-                   'Topic :: Software Development :: Libraries :: Python Modules',
+                   'Topic :: Software Development :: Libraries :: Python Modules',  # NOQA
                   ],
       keywords='jenkins xml yaml',
       author='ken dreyer',


### PR DESCRIPTION
Fix a couple of whitespace things that bother flake8.

Add NOQA to a particularly long trove classifier line.