### PR TITLE
fix issue with empty adminlist

### DIFF
--- a/jenkins_job_wrecker/job_handlers.py
+++ b/jenkins_job_wrecker/job_handlers.py
@@ -533,7 +533,11 @@ def handle_triggers(top):
                     if tagname == 'spec' or tagname == 'cron':
                         ghpr['cron'] = ghprel.text
                     elif tagname == 'adminlist':
-                        ghpr['admin-list'] = ghprel.text.strip().split('\n')
+                        ghprel_text = ghprel.text
+                        if ghprel_text:
+                            ghpr['admin-list'] = ghprel.text.strip().split('\n')
+                        else:
+                            ghpr['admin-list'] = ['']
                     elif tagname == 'allowMembersOfWhitelistedOrgsAsAdmin':
                         ghpr['allow-whitelist-orgs-as-admins'] = get_bool(ghprel.text)
                     elif tagname == 'whitelist' and ghprel.text is not None:

--- a/jenkins_job_wrecker/job_handlers.py
+++ b/jenkins_job_wrecker/job_handlers.py
@@ -536,8 +536,6 @@ def handle_triggers(top):
                         ghprel_text = ghprel.text
                         if ghprel_text:
                             ghpr['admin-list'] = ghprel.text.strip().split('\n')
-                        else:
-                            ghpr['admin-list'] = ['']
                     elif tagname == 'allowMembersOfWhitelistedOrgsAsAdmin':
                         ghpr['allow-whitelist-orgs-as-admins'] = get_bool(ghprel.text)
                     elif tagname == 'whitelist' and ghprel.text is not None:


### PR DESCRIPTION
I recently ran into a Jenkins job that uses this plugin:
`<org.jenkinsci.plugins.ghprb.GhprbTrigger plugin="ghprb@1.33.1">`
which for some reason had an empty `adminlist`:
`<adminlist></adminlist>`

This caused an `AttributeError`:
```
$ jjwrecker -f sample-job.xml -n sample-job
last called handle_triggers
Traceback (most recent call last):
[...]
  File "/path/to/jenkins_job_wrecker/job_handlers.py", line 536, in handle_triggers
    ghpr['admin-list'] = ghprel.text.strip().split('\n')
AttributeError: 'NoneType' object has no attribute 'strip'
```
This PR should deal with it.