### PR TITLE
Remove custom logging formatter

### DIFF
--- a/jenkins_job_wrecker/cli.py
+++ b/jenkins_job_wrecker/cli.py
@@ -19,13 +19,6 @@ if is_py_v2:
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger('jjwrecker')
 
-# set the format of the standard StreamHandler to have a space in it
-# (on the root logger)
-for handler in logging.getLogger().handlers:
-    if isinstance(handler, logging.StreamHandler):
-        handler.setFormatter(logging.Formatter(fmt='%(name)s %(levelname)s: '
-                                                   '%(message)s'))
-
 
 def str_presenter(dumper, data):
   if len(data.splitlines()) > 1:  # check for multiline string


### PR DESCRIPTION
I noticed that importing (using as a library) causes issues with logging, e.g.
`from jenkins_job_wrecker.cli import root_to_yaml`
I also found this:
http://pieces.openpolitics.com/2012/04/python-logging-best-practices/
This change should fix the logging issues without negatively impacting the command-line use-case of `jjwrecker`:

- Before
```
jjwrecker INFO: looking up job "acceptance_tests_china"
jjwrecker INFO: converting job "acceptance_tests_china" to YAML
```

- After
```
INFO:jjwrecker:looking up job "acceptance_tests_china"
INFO:jjwrecker:converting job "acceptance_tests_china" to YAML
```