### PR TITLE
Fix issue with non-ascii character in shell script text

### DIFF
--- a/jenkins_job_wrecker/cli.py
+++ b/jenkins_job_wrecker/cli.py
@@ -20,6 +20,7 @@ if is_py_v2:
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger('jjwrecker')
 
+class literal_unicode(unicode): pass
 
 def str_presenter(dumper, data):
   if len(data.splitlines()) > 1:  # check for multiline string
@@ -32,6 +33,7 @@ def str_presenter(dumper, data):
   return dumper.represent_scalar('tag:yaml.org,2002:str', data)
 
 yaml.add_representer(str, str_presenter)
+yaml.add_representer(literal_unicode, str_presenter)
 
 
 # Given a file with XML, or a string of XML, parse it with
@@ -52,7 +54,7 @@ def root_to_yaml(root, name):
     job = {}
     build = [{'job': job}]
 
-    job['name'] = str(name)
+    job['name'] = unicode(name)
 
     # Create register
     reg = Registry()

--- a/jenkins_job_wrecker/modules/builders.py
+++ b/jenkins_job_wrecker/modules/builders.py
@@ -81,7 +81,7 @@ def shell(child, parent):
         # <hudson.tasks.Shell>
         if shell_element.tag == 'command':
             if shell_element.text is not None:
-                shell = str(shell_element.text)
+                shell = shell_element.text
         else:
             raise NotImplementedError("cannot handle "
                                       "XML %s" % shell_element.tag)

--- a/tests/fixtures/non-ascii.xml
+++ b/tests/fixtures/non-ascii.xml
@@ -1,0 +1,24 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties/>
+  <scm class="hudson.scm.NullSCM"/>
+  <canRoam>true</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers/>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>echo &quot;Hello&quot;
+echo &quot;你好&quot;
+echo &quot;こんにちは&quot;
+echo &quot;привет&quot;</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers/>
+  <buildWrappers/>
+</project>

--- a/tests/test_jjb.py
+++ b/tests/test_jjb.py
@@ -3,7 +3,7 @@ from jenkins_job_wrecker.cli import get_xml_root, root_to_yaml
 import os
 import pytest
 import tempfile
-#import jenkins_jobs.cmd
+import jenkins_jobs.cmd
 from subprocess import call
 
 fixtures_path = os.path.join(os.path.dirname(__file__), 'fixtures')
@@ -18,11 +18,10 @@ class TestJJB(object):
         yaml = root_to_yaml(root, jobname)
 
         # Run this wrecker YAML thru JJB.
-	# XXX: shelling out with call() sucks; use JJB's API instead
         temp = tempfile.NamedTemporaryFile()
         temp.write(yaml)
         temp.flush()
-        assert call(["jenkins-jobs", 'test', temp.name]) == 0
+        assert jenkins_jobs.cmd.main(['test', temp.name]) is None
         temp.close()
 
     def test_ice_setup(self):

--- a/tests/test_jjb.py
+++ b/tests/test_jjb.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from jenkins_job_wrecker.cli import get_xml_root, root_to_yaml
 import os
 import pytest
@@ -9,10 +10,12 @@ fixtures_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 
 class TestJJB(object):
 
-    def run_jjb(self, name):
+    def run_jjb(self, name, jobname=None):
         filename = os.path.join(fixtures_path, name + '.xml')
         root = get_xml_root(filename=filename)
-        yaml = root_to_yaml(root, name)
+        if jobname is None:
+            jobname = name
+        yaml = root_to_yaml(root, jobname)
 
         # Run this wrecker YAML thru JJB.
 	# XXX: shelling out with call() sucks; use JJB's API instead
@@ -27,3 +30,6 @@ class TestJJB(object):
 
     def test_calamari_clients(self):
         self.run_jjb('calamari-clients')
+
+    def test_non_ascii(self):
+        self.run_jjb('non-ascii', 'テスト')


### PR DESCRIPTION
I got `UnicodeDecodeError` when using non-ascii character in shell script.

```
UnicodeDecodeError: 'utf8' codec can't decode byte 0xe3 in position 0: unexpected end of data
```

## How to reproduce

I added some non-ascii test. This test can can reproduce the error on `v1.0.11` or `v1.1.0`(latest), but not on `v1.0.10`. So is seems `v1.0.11` is the first version to reproduce.

https://github.com/ktdreyer/jenkins-job-wrecker/compare/v1.0.10...v1.0.11

I think this error occurred by following reasons.

- `xml.etree.ElementTree` parses xml text node as type `<unicode>`, when a xml text node contains non-ascii character.

- In Shell builder, shell script text was converted to type `str` by calling `str(shell_element.text)`.   https://github.com/ktdreyer/jenkins-job-wrecker/blob/master/jenkins_job_wrecker/builders.py#L89  
  This convert runs anytime even if shell script text was parsed as type `<unicode>` by containing non-ascii character. Note that we can reproduce `UnicodeDecodeError` by following.

```
#!/usr/bin/env python2.7
# -*- coding: utf-8 -*-
import sys
import yaml
reload(sys)
sys.setdefaultencoding('utf-8')
yaml.add_representer(str, lambda dumper, data: dumper.represent_scalar('tag:yaml.org,2002:str', data))
yaml.dump(str(u'你好')) #=> throws UnicodeDecodeError: 'utf8' codec can't decode byte 0xbd in position 0: invalid start byte
```

- (`v1.0.10` or lower) Shell script text was converted to type `<str>`.
  And it was re-converted to literal_unicode by `format_shell_scripts` method.  
  https://github.com/ktdreyer/jenkins-job-wrecker/blob/v1.0.10/jenkins_job_wrecker/cli.py#L108  
  So after all, `shell_element.text` was treated as type `<unicode>`.

- (`v1.0.11` or higher) the `format_shell_scripts` method was removed.
  So `shell_element.text` was treated as type `<str>`, and this occurs `UnicodeDecodeError`.


## How to fix

- In shell builder, treat `shell_element.text` as is.
- Revert unicode representer.