### PR TITLE
Various fixes

### DIFF
--- a/jenkins_job_wrecker/cli.py
+++ b/jenkins_job_wrecker/cli.py
@@ -54,15 +54,18 @@ def root_to_yaml(root, name):
 
     job['name'] = str(name)
 
+    # Create register
+    reg = Registry()
+
     # "project-type:" YAML
-    project_types = {
-        'project': 'freestyle',
-        'matrix-project': 'matrix'}
+    project_types = reg.get_project_types()
+
     if root.tag in project_types:
         job['project-type'] = project_types[root.tag]
 
-        # Handle each top-level XML element with custom "handle_*" functions in
-        # modudles/handlers.py.
+        # Handle each top-level XML element with custom modules/functions in
+        # modules/handlers.py
+        # registry determines difference at runtime
         reg = Registry()
         handlers = Handlers(reg)
         handlers.gen_yml(job, root)

--- a/jenkins_job_wrecker/modules/builders.py
+++ b/jenkins_job_wrecker/modules/builders.py
@@ -87,3 +87,18 @@ def shell(child, parent):
                                       "XML %s" % shell_element.tag)
 
     parent.append({'shell': shell})
+
+
+def batchfile(child, parent):
+    shell = ''
+    for shell_element in child:
+        # Assumption: there's only one <command> in this
+        # <hudson.tasks.Shell>
+        if shell_element.tag == 'command':
+            if shell_element.text is not None:
+                shell = str(shell_element.text)
+        else:
+            raise NotImplementedError("cannot handle "
+                                      "XML %s" % shell_element.tag)
+
+    parent.append({'batch': shell})

--- a/setup.py
+++ b/setup.py
@@ -84,9 +84,6 @@ setup(name="jenkins-job-wrecker",
           'console_scripts': [
               'jjwrecker = jenkins_job_wrecker.cli:main',
           ],
-          'jenkins_job_wrecker.builders': [
-              'batchfile = jenkins_job_wrecker.modules.builders:shell'
-          ],
       },
       tests_require=[
           'pytest',


### PR DESCRIPTION
- Check buildtrigger is not a parameterized trigger
- Mailer: 'send email on every failed build' is inverse bool
- Remove entry_point for batchfile to prevent conflicts
- Amended registry to allow flexibly defining supported project types
- Updated registry to check for duplicate entry points and raise exception if so
- Fixed parameter parsing, added support for text and file parameters