### PR TITLE
Correct tag for flow

### DIFF
--- a/jenkins_job_wrecker/registry.py
+++ b/jenkins_job_wrecker/registry.py
@@ -33,7 +33,7 @@ class Registry(object):
         if len(self.project_types) == 0:
             valid_types = {'project': 'freestyle',
                            'matrix-project': 'matrix',
-                           'flow-definition': 'flow'}
+                           'com.cloudbees.plugins.flow.BuildFlow': 'flow'}
             for name, item in self._get_entry_points('jenkins_job_wrecker.projects').iteritems():
                 valid_types.update(item)
             self.project_types.update(valid_types)


### PR DESCRIPTION
registry.py currently assumes 'flow-definition' means 'flow' in jenkins-job-builder, when it actually means 'com.cloudbees.plugins.flow.BuildFlow'. Correcting this to prevent incorrect yaml being created for pipeline projects.