### PR TITLE
Add missing re import for slack publisher

### DIFF
--- a/jenkins_job_wrecker/modules/publishers.py
+++ b/jenkins_job_wrecker/modules/publishers.py
@@ -1,4 +1,6 @@
 # encoding=utf8
+import re
+
 import jenkins_job_wrecker.modules.base
 from jenkins_job_wrecker.helpers import get_bool
 


### PR DESCRIPTION
`slacknotifier` uses `re.sub` but it is not imported in the module.