### PR TITLE
MANIFEST.in: drop non-existent README file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
 include setup.py
-include README.md
 include LICENSE


### PR DESCRIPTION
I translated the README to rST a while back but forgot to drop this
line from MANIFEST.in.

Setuptools automatically includes any file named "README.rst" so we
don't need to list it explicitly here.