### PR TITLE
Fix bug with incorrect name for sequential in execution-strategy

### DIFF
--- a/jenkins_job_wrecker/modules/handlers.py
+++ b/jenkins_job_wrecker/modules/handlers.py
@@ -108,7 +108,7 @@ def executionstrategy(top, parent):
     for child in top:
 
         if child.tag == 'runSequentially':
-            strategy['run-sequentially'] = (child.text == 'true')
+            strategy['sequential'] = (child.text == 'true')
         elif child.tag == 'sorter':
             # Is there anything but NOOP?
             pass


### PR DESCRIPTION
JJB uses 'sequential' instead of run-sequentially.

See https://git.openstack.org/cgit/openstack-infra/jenkins-job-builder/tree/jenkins_jobs/modules/project_matrix.py#n52

```
    * **execution-strategy** (optional, built in Jenkins):
        * **combination-filter** (`str`): axes selection filter
        * **sequential** (`bool`): run builds sequentially (default false)
        * **touchstone** (optional):
            * **expr** (`str`) -- selection filter for the touchstone build
            * **result** (`str`) -- required result of the job: \
            stable (default) or unstable
```