### PR TITLE
Pipeline script beginning support

### DIFF
--- a/jenkins_job_wrecker/modules/handlers.py
+++ b/jenkins_job_wrecker/modules/handlers.py
@@ -16,6 +16,8 @@ class Handlers(jenkins_job_wrecker.modules.base.Base):
                 for setting in settings:
                     key, value = setting
                     if key in yml_parent:
+                        if not value:
+                            continue
                         yml_parent[key].append(value[0])
                     else:
                         yml_parent[key] = value
@@ -180,7 +182,11 @@ def definition(top, parent):
 
     # sub-level "definition" data
     definition = {}
-    parent.append(['definition', definition])
+    if 'class' in top.attrib:  # Pipeline scm
+        if top.attrib['class'] == 'org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition':
+            parent.append(['pipeline-scm', definition])
+    else:
+        parent.append(['definition', definition])
     reg = Registry()
     handlers = Handlers(reg)
     handlers.gen_yml(definition, top)

--- a/jenkins_job_wrecker/modules/properties.py
+++ b/jenkins_job_wrecker/modules/properties.py
@@ -1,6 +1,7 @@
 # encoding=utf8
 import jenkins_job_wrecker.modules.base
 from jenkins_job_wrecker.helpers import get_bool, gen_raw
+from jenkins_job_wrecker.modules.triggers import Triggers
 
 PARAMETER_MAPPER = {
     'stringparameterdefinition': 'string',
@@ -22,6 +23,14 @@ class Properties(jenkins_job_wrecker.modules.base.Base):
             object_name = object_name.replace('-', '').replace('_', '')
             if object_name == 'parametersdefinitionproperty':
                 self.registry.dispatch(self.component, 'parameters', child, parameters)
+                continue
+            elif object_name == 'pipelinetriggersjobproperty':
+                # Pipeline scripts put triggers in properties section
+                trigger = Triggers(self.registry)
+                for grandchild in child:
+                    # Find the triggers tag and then generate the yaml
+                    if grandchild.tag == 'triggers':
+                        trigger.gen_yml(yml_parent, grandchild)
                 continue
             self.registry.dispatch(self.component, object_name, child, properties)
 

--- a/jenkins_job_wrecker/modules/scm.py
+++ b/jenkins_job_wrecker/modules/scm.py
@@ -187,6 +187,18 @@ def gitscm(top, parent):
                     git['local-branch'] = extension[0].text
                 elif extension.tag == 'hudson.plugins.git.extensions.impl.PerBuildTag':
                     pass
+                elif extension.tag == 'hudson.plugins.git.extensions.impl.CleanBeforeCheckout':
+                    clean_dict = {'before': True}
+                    if 'clean' in git:  # after has already been added
+                        git['clean'].update(clean_dict)
+                    else:  # Need to create dict for git['clean']
+                        git['clean'] = clean_dict
+                elif extension.tag == 'hudson.plugins.git.extensions.impl.CleanAfterCheckout':
+                    clean_dict = {'after': True}
+                    if 'clean' in git:  # before has already been added
+                        git['clean'].update(clean_dict)
+                    else:  # Need to create dict for git['clean']
+                        git['clean'] = clean_dict
                 else:
                     raise NotImplementedError("%s not supported" % extension.tag)
 


### PR DESCRIPTION
I was able to get basic pipeline configs working. This basically:

1. Adds the flow-definition to get_project_types()
2. Adds support for the pipeline-scm info, as it is in a definition block. This PR handles the different yaml syntax for that.
3. Fixes the GitHub PR Builder support for pipelines. The Github PR builder configuration goes into a <triggers> block inside of the <properties> block (as discussed in #69). This PR checks for that in the properties class and makes a Trigger object if it sees that.
4. Makes the hard fail on the <actions> tag optional. This PR adds a command line argument (`-a` or `--ignore-action-tag`) to just completely ignore the actions info if it finds information in it. This is useful if there is any action info that isn't mission critical but the user still wants the job to be converted.

Feel free to request/make changes and ask questions. My goal is to see the project improved as much as possible, it is very cool and useful 😄 .