### PR TITLE
Fix some bugs with Pipeline and Folder stuff

### DIFF
--- a/jenkins_job_wrecker/cli.py
+++ b/jenkins_job_wrecker/cli.py
@@ -206,25 +206,25 @@ def main():
         if args.name:
             job_names = [args.name]
         else:
-            job_names = {}  # {'name':'fullname'}
+            job_names = []
             # Folder depth of None means go down indefinitely
             for job in server.get_jobs(folder_depth=None):
                 if args.ignore and job['name'] in args.ignore:
                     log.info('Ignoring \"%s\" as requested...' % job['name'])
                     continue
 
-                job_names[job['name']] = job['fullname']
+                job_names.append(job['fullname'])
 
         # write YAML
-        for name, fullname in job_names.items():
+        for fullname in job_names:
             log.info('looking up job "%s"' % fullname)
             # Get a job's XML
             xml = server.get_job_config(fullname)
             log.debug(xml)
             # Convert XML to YAML
             root = get_xml_root(string=xml)
-            log.info('converting job "%s" to YAML' % name)
-            yaml = root_to_yaml(root, name, args.ignore_actions_tag)
+            log.info('converting job "%s" to YAML' % fullname)
+            yaml = root_to_yaml(root, fullname, args.ignore_actions_tag)
             # Create output directory structure where needed
             yaml_filename = os.path.join('output', fullname + '.yml')
             path = os.path.dirname(yaml_filename)

--- a/jenkins_job_wrecker/modules/handlers.py
+++ b/jenkins_job_wrecker/modules/handlers.py
@@ -1,5 +1,6 @@
 import jenkins_job_wrecker.modules.base
 from jenkins_job_wrecker.registry import Registry
+from jenkins_job_wrecker.helpers import get_bool
 
 
 class Handlers(jenkins_job_wrecker.modules.base.Base):
@@ -182,9 +183,19 @@ def definition(top, parent):
 
     # sub-level "definition" data
     definition = {}
-    if 'class' in top.attrib:  # Pipeline scm
+    if 'class' in top.attrib:  # Pipeline script
         if top.attrib['class'] == 'org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition':
+            #  Using pipeline-scm (getting jenkinsfile from repo)
             parent.append(['pipeline-scm', definition])
+        elif top.attrib['class'] == 'org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition':
+            # Using DSL (passing raw pipeline script)
+            for child in top.getchildren():
+                if child.tag == 'script':
+                    parent.append(['dsl', child.text])
+                elif child.tag == 'sandbox':
+                    parent.append(['sandbox', get_bool(child.text)])
+            # Don't pass anything to handlers.gen_yml, handled it here
+            top = ''
     else:
         parent.append(['definition', definition])
     reg = Registry()


### PR DESCRIPTION
I noticed some bugs yesterday after running the script across our Jenkins server.

First being that I used the short name of jobs as the key in the `job_names` dictionary, so if two folders were named the same but were located in different parent folders, one would overwrite the other in the dictionary. I realized that short name isn't really needed anyways, so I've converted job_names back to a list that only stores the full names of jobs.

The other being that I forgot about having raw DSL as an option for pipeline scripts, so I have added that as well. I'm curious what you think about this part @ktdreyer, I feel like there should be a better way to do this, but the format of the tags are weird so the way I did it may be the only way. I can post an example of what the XML looks like and what the outputted YAML should look like if that helps.