### PR TITLE
setup.py: signing, upload, and flake8 fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ class ReleaseCommand(Command):
         print(' '.join(cmd))
         subprocess.check_call(cmd)
 
+
 setup(name="jenkins-job-wrecker",
       version=version,
       description=('convert Jenkins XML to YAML'),

--- a/setup.py
+++ b/setup.py
@@ -55,10 +55,23 @@ class ReleaseCommand(Command):
         print(' '.join(cmd))
         subprocess.check_call(cmd)
 
-        # Push package to pypi
-        cmd = ['python', 'setup.py', 'sdist', 'upload']
+        # Create source package
+        cmd = ['python', 'setup.py', 'sdist']
+        print(' '.join(cmd))
+        subprocess.check_call(cmd)
+
+        tarball = 'dist/%s-%s.tar.gz' % ('jenkins-job-wrecker', version)
+
+        # GPG sign
         if self.sign:
-            cmd.append('--sign')
+            cmd = ['gpg2', '-b', '-a', tarball]
+            print(' '.join(cmd))
+            subprocess.check_call(cmd)
+
+        # Upload
+        cmd = ['twine', 'upload', tarball]
+        if self.sign:
+            cmd.append(tarball + '.asc')
         print(' '.join(cmd))
         subprocess.check_call(cmd)
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import subprocess
 import sys
 from setuptools import setup, find_packages, Command
@@ -41,24 +42,24 @@ class ReleaseCommand(Command):
         cmd = ['git', 'tag', '-a', tag_name, '-m', 'version %s' % version]
         if self.sign:
             cmd.append('-s')
-        print ' '.join(cmd)
+        print(' '.join(cmd))
         subprocess.check_call(cmd)
 
         # Push Git tag to origin remote
         cmd = ['git', 'push', 'origin', tag_name]
-        print ' '.join(cmd)
+        print(' '.join(cmd))
         subprocess.check_call(cmd)
 
         # Push branch to origin remote
         cmd = ['git', 'push', 'origin', 'master']
-        print ' '.join(cmd)
+        print(' '.join(cmd))
         subprocess.check_call(cmd)
 
         # Push package to pypi
         cmd = ['python', 'setup.py', 'sdist', 'upload']
         if self.sign:
             cmd.append('--sign')
-        print ' '.join(cmd)
+        print(' '.join(cmd))
         subprocess.check_call(cmd)
 
 setup(name="jenkins-job-wrecker",


### PR DESCRIPTION
* Make setup.py use `print()`
* Change `python setup.py release` to call the modern tools I use:
  * Use `gpg2` to sign
  * Use `twine` to upload
* whitespace flake8 fix