### PR TITLE
Views

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,10 @@ before hand or right before running the CLI tool::
      JJW_USERNAME=alfredo JJW_PASSWORD=go-tamaulipas jjwrecker -s
      http://jenkins.ceph.com
 
+If you receive the error ``Don't know how to handle a non-empty <actions> element.``,
+you have actions in your xml for that job (probably from plugins). If you know that
+you don't need this information in your JJB yml job config, try the ``-a`` flag.
+
 If your Jenkins instance is using HTTPS and protected by a custom CA, add the
 CA's public cert to your system certificate store:
 

--- a/jenkins_job_wrecker/cli.py
+++ b/jenkins_job_wrecker/cli.py
@@ -8,6 +8,7 @@ import os
 import sys
 import textwrap
 from jenkins_job_wrecker.modules.handlers import Handlers
+from jenkins_job_wrecker.modules.listview import Listview
 from jenkins_job_wrecker.registry import Registry
 import xml.etree.ElementTree as ET
 import yaml
@@ -57,9 +58,8 @@ def get_xml_root(filename=False, string=False):
 def root_to_yaml(root, name, ignore_actions=False):
     # Top-level "job" data
     job = {}
-    build = [{'job': job}]
-
     job['name'] = unicode(name)
+    build = []
 
     # Create register
     reg = Registry()
@@ -73,7 +73,13 @@ def root_to_yaml(root, name, ignore_actions=False):
         # Handle each top-level XML element with custom modules/functions in
         # modules/handlers.py
         # registry determines difference at runtime
-        if job['project-type'] != 'folder':
+        if job['project-type'] == 'listview':
+            build.append({'view': job})
+            reg = Registry(ignore_actions=ignore_actions)
+            viewhandler = Listview(reg)
+            viewhandler.gen_yml(job, root)
+        elif job['project-type'] != 'folder':
+            build.append({'job': job})
             reg = Registry(ignore_actions=ignore_actions)
             handlers = Handlers(reg)
             handlers.gen_yml(job, root)
@@ -111,6 +117,10 @@ def parse_args(args):
         help='Name of a job'
     )
     parser.add_argument(
+        '-u', '--view',
+        help='Name of a view'
+    )
+    parser.add_argument(
         '-i', '--ignore',
         nargs='*',
         help='Ignore some jobs in conversion.'
@@ -142,8 +152,8 @@ def main():
 
     # Options:
     # -f and -n
-    # -s and -n
-    # TODO: -s (without -n means "all jobs on the server")
+    # -s and -n/-u
+    # -s (without -n means "all jobs on the server")
     # Choose either -f or -s ...
     if not args.jenkins_server and not args.filename:
         log.critical('Choose an XML file (-f) or Jenkins URL (-s).')
@@ -155,8 +165,9 @@ def main():
         exit(1)
 
     # -f requires -n
-    if args.filename and not args.name:
-        log.critical('Choose a job name (-n) for the job in this file.')
+    if args.filename and not args.name and not args.view:
+        log.critical('Choose a job name (-n) or a view name (-u) for the job'
+                     ' in this file.')
         exit(1)
 
     # Args are ok. Proceed with writing output
@@ -170,7 +181,7 @@ def main():
     if args.filename:
         # Convert to YAML
         root = get_xml_root(filename=args.filename)
-        yaml = root_to_yaml(root, args.name)
+        yaml = root_to_yaml(root, args.name, args.ignore_actions_tag)
         # Create output directory structure where needed
         yaml_filename = os.path.join(args.output_dir, args.name + '.yml')
         path = os.path.dirname(yaml_filename)
@@ -215,27 +226,58 @@ def main():
 
                 job_names.append(job['fullname'])
 
-        # write YAML
-        for fullname in job_names:
-            log.info('looking up job "%s"' % fullname)
-            # Get a job's XML
-            xml = server.get_job_config(fullname)
-            log.debug(xml)
-            # Convert XML to YAML
-            root = get_xml_root(string=xml)
-            log.info('converting job "%s" to YAML' % fullname)
-            yaml = root_to_yaml(root, fullname, args.ignore_actions_tag)
-            # Create output directory structure where needed
-            yaml_filename = os.path.join('output', fullname + '.yml')
-            path = os.path.dirname(yaml_filename)
-            try:
-                os.makedirs(path)
-            except OSError as exc:  # Python >2.5
-                if exc.errno == errno.EEXIST and os.path.isdir(path):
-                    pass
+        if args.view:
+            view_names = [args.view]
+        else:
+            view_names = []
+            for view in server.get_views():
+                if args.ignore and view['name'] in args.ignore:
+                    log.info('Ignoring \"%s\" as requested...' % view['name'])
+                    continue
+
+                if view['name'] != 'all':
+                    view_names.append(view['name'])
+
+        def convert_to_yml(job_names, element_type, output_dir='output'):
+            """
+            Takes a list of job or view names and converts them all to YAML and
+            writes them to a file.
+
+            :param list[str] job_names: Either job names or view names to get
+                configs for from the server.
+            :param str element_type: The type of job_names. Either 'job' or
+                'view' currently.
+            :param str output_dir: The directory to write the files to.
+            """
+            for fullname in job_names:
+                log.info('looking up %s "%s"' % (element_type, fullname))
+                # Get a job's XML
+                if element_type == 'job':
+                    xml = server.get_job_config(fullname)
+                elif element_type == 'view':
+                    xml = server.get_view_config(fullname)
                 else:
-                    raise
-            # Write to output file
-            output_file = open(yaml_filename, 'w')
-            output_file.write(yaml)
-            output_file.close()
+                    log.critical('Invalid element_type.')
+                    exit(1)
+                log.debug(xml)
+                # Convert XML to YAML
+                root = get_xml_root(string=xml)
+                log.info('converting %s "%s"' % (element_type, fullname))
+                yaml = root_to_yaml(root, fullname, args.ignore_actions_tag)
+                # Create output directory structure where needed
+                yaml_filename = os.path.join(output_dir, fullname + '.yml')
+                path = os.path.dirname(yaml_filename)
+                try:
+                    os.makedirs(path)
+                except OSError as exc:  # Python >2.5
+                    if exc.errno == errno.EEXIST and os.path.isdir(path):
+                        pass
+                    else:
+                        raise
+                # Write to output file
+                output_file = open(yaml_filename, 'w')
+                output_file.write(yaml)
+                output_file.close()
+
+        convert_to_yml(job_names, 'job')
+        convert_to_yml(view_names, 'view', output_dir='output/views')

--- a/jenkins_job_wrecker/cli.py
+++ b/jenkins_job_wrecker/cli.py
@@ -10,6 +10,7 @@ import textwrap
 from jenkins_job_wrecker.modules.handlers import Handlers
 from jenkins_job_wrecker.modules.listview import Listview
 from jenkins_job_wrecker.registry import Registry
+from jenkins_job_wrecker.helpers import gen_raw
 import xml.etree.ElementTree as ET
 import yaml
 
@@ -216,7 +217,7 @@ def main():
 
         if args.name:
             job_names = [args.name]
-        else:
+        elif not args.view:
             job_names = []
             # Folder depth of None means go down indefinitely
             for job in server.get_jobs(folder_depth=None):
@@ -225,10 +226,12 @@ def main():
                     continue
 
                 job_names.append(job['fullname'])
+        else:
+            job_names = []
 
         if args.view:
             view_names = [args.view]
-        else:
+        elif not args.name:
             view_names = []
             for view in server.get_views():
                 if args.ignore and view['name'] in args.ignore:
@@ -237,6 +240,8 @@ def main():
 
                 if view['name'] != 'all':
                     view_names.append(view['name'])
+        else:
+            view_names = []
 
         def convert_to_yml(job_names, element_type, output_dir='output'):
             """

--- a/jenkins_job_wrecker/modules/listview.py
+++ b/jenkins_job_wrecker/modules/listview.py
@@ -1,6 +1,6 @@
 # encoding=utf8
 import jenkins_job_wrecker.modules.base
-from jenkins_job_wrecker.helpers import get_bool
+from jenkins_job_wrecker.helpers import get_bool, gen_raw
 
 
 class Listview(jenkins_job_wrecker.modules.base.Base):
@@ -30,23 +30,123 @@ class Listview(jenkins_job_wrecker.modules.base.Base):
 
         for child in data:
             if child.tag == 'name':
-                continue
+                continue  # Name already declared in other section of YAML
+            elif child.tag == 'description':
+                view['description'] = child.text
             elif child.tag == 'filterExecutors':
-                view['filter-executors'] = get_bool(child.tag)
+                view['filter-executors'] = get_bool(child.text)
             elif child.tag == 'filterQueue':
-                view['filter-queue'] = get_bool(child.tag)
+                view['filter-queue'] = get_bool(child.text)
+            elif child.tag == 'jobFilters':
+                filters = {}
+                for gchild in child:
+                    # most-recent filter
+                    if gchild.tag == 'hudson.views.MostRecentJobsFilter':
+                        recent = {}
+                        filters['most-recent'] = recent
+                        for ggchild in gchild:
+                            if ggchild.tag == 'maxToInclude':
+                                recent['max-to-include'] = int(ggchild.text)
+                            elif ggchild.tag == 'checkStartTime':
+                                recent['check-start-time'] = get_bool(ggchild.text)
+                            else:
+                                raise NotImplementedError("cannot handle XML %s" % ggchild.tag)
+                    # build-duration filter
+                    elif gchild.tag == 'hudson.views.BuildDurationFilter':
+                        builddur = {}
+                        filters['build-duration'] = builddur
+                        for ggchild in gchild:
+                            if ggchild.tag == 'includeExcludeTypeString':
+                                builddur['match-type'] = ggchild.text
+                            elif ggchild.tag == 'buildCountTypeString':
+                                builddur['build-duration-type'] = ggchild.text
+                            elif ggchild.tag == 'amountTypeString':
+                                builddur['amount-type'] = ggchild.text
+                            elif ggchild.tag == 'amount':
+                                builddur['amount'] = int(ggchild.text)
+                            elif ggchild.tag == 'lessThan':
+                                builddur['less-than'] = get_bool(ggchild.text)
+                            elif ggchild.tag == 'buildDurationMinutes':
+                                builddur['build-duration-minutes'] = int(ggchild.text)
+                            else:
+                                raise NotImplementedError("cannot handle XML %s" % ggchild.tag)
+                    # build-trend filter
+                    elif gchild.tag == 'hudson.views.BuildTrendFilter':
+                        trend = {}
+                        filters['build-trend'] = trend
+                        for ggchild in gchild:
+                            if ggchild.tag == 'includeExcludeTypeString':
+                                trend['match-type'] = ggchild.text
+                            elif ggchild.tag == 'buildCountTypeString':
+                                trend['build-trend-type'] = ggchild.text
+                            elif ggchild.tag == 'amountTypeString':
+                                trend['amount-type'] = ggchild.text
+                            elif ggchild.tag == 'amount':
+                                trend['amount'] = int(ggchild.text)
+                            elif ggchild.tag == 'statusTypeString':
+                                trend['status'] = ggchild.text
+                            else:
+                                raise NotImplementedError("cannot handle XML %s" % ggchild.tag)
+                    # job-status filter
+                    elif gchild.tag == 'hudson.views.JobStatusFilter':
+                        status = {}
+                        filters['job-status'] = status
+                        for ggchild in gchild:
+                            if ggchild.tag == 'includeExcludeTypeString':
+                                status['match-type'] = ggchild.text
+                            elif ggchild.tag == 'unstable':
+                                status['unstable'] = get_bool(ggchild.text)
+                            elif ggchild.tag == 'failed':
+                                status['failed'] = get_bool(ggchild.text)
+                            elif ggchild.tag == 'aborted':
+                                status['aborted'] = get_bool(ggchild.text)
+                            elif ggchild.tag == 'disabled':
+                                status['disabled'] = get_bool(ggchild.text)
+                            elif ggchild.tag == 'stable':
+                                status['stable'] = get_bool(ggchild.text)
+                            else:
+                                raise NotImplementedError("cannot handle XML %s" % ggchild.tag)
+                    # Need to gen raw for filters, not implemented at all
+                    else:
+                        filters = {}  # Empty out filters
+                        raw_xml = []
+                        gen_raw(child, raw_xml)
+                        raw_str_xml = raw_xml[0]['raw']['xml']
+                        # Needs to be ['raw']['xml'], not [0]['raw']['xml'],
+                        #   as view is a dictionary
+                        if 'raw' not in view:
+                            view['raw'] = {'xml': raw_str_xml}
+                        else:
+                            view['raw']['xml'] += raw_str_xml
+                        break
+                # End of jobFilters loop
+                if filters:
+                    view['job-filters'] = filters
+            # End of jobFilters
             elif child.tag == 'jobNames':
                 jobs = []
                 for gchild in child:
                     if gchild.tag == 'string':
                         jobs.append(gchild.text)
-                view['job-name'] = jobs
+                if jobs:
+                    view['job-name'] = jobs
             elif child.tag == 'columns':
+                if len(child) == 0:
+                    continue
                 columns = []
                 for gchild in child:
                     if gchild.tag in self.COLUMN_DICT:
                         columns.append(self.COLUMN_DICT[gchild.tag])
                 view['columns'] = columns
             elif child.tag == 'recurse':
-                view['recurse'] = get_bool(child.tag)
+                view['recurse'] = get_bool(child.text)
+            elif child.tag == 'includeRegex':
+                view['regex'] = child.text
+            elif child.tag == 'statusFilter':
+                view['status-filter'] = get_bool(child.text)
+            elif child.tag == 'properties':
+                # Not sure what this tag is for, doesn't seem important
+                continue
+            else:
+                raise NotImplementedError("cannot handle XML %s" % child.tag)
         yml_parent.update(view)

--- a/jenkins_job_wrecker/modules/listview.py
+++ b/jenkins_job_wrecker/modules/listview.py
@@ -1,0 +1,52 @@
+# encoding=utf8
+import jenkins_job_wrecker.modules.base
+from jenkins_job_wrecker.helpers import get_bool
+
+
+class Listview(jenkins_job_wrecker.modules.base.Base):
+    component = 'listview'
+
+    COLUMN_DICT = {
+        'hudson.views.StatusColumn': 'status',
+        'hudson.views.WeatherColumn': 'weather',
+        'hudson.views.JobColumn': 'job',
+        'hudson.views.LastSuccessColumn': 'last-success',
+        'hudson.views.LastFailureColumn': 'last-failure',
+        'hudson.views.LastDurationColumn': 'last-duration',
+        'hudson.views.BuildButtonColumn': 'build-button',
+        'hudson.views.LastStableColumn': 'last-stable',
+        'hudson.plugins.robot.view.RobotListViewColum': 'robot-list',
+        'hudson.plugins.findbugs.FindBugsColumn': 'find-bugs',
+        'hudson.plugins.jacococoveragecolumn.JaCoCoColumn': 'jacoco',
+        'hudson.plugins.git.GitBranchSpecifierColumn': 'git-branch',
+        'org.jenkinsci.plugins.schedulebuild.ScheduleBuildButtonColumn': 'schedule-build',
+        'jenkins.advancedqueue.PrioritySorterJobColumn': 'priority-sorter',
+        'hudson.views.BuildFilterColumn': 'build-filter',
+        'jenkins.branch.DescriptionColumn': 'desc',
+    }
+
+    def gen_yml(self, yml_parent, data):
+        view = {'view-type': 'list'}
+
+        for child in data:
+            if child.tag == 'name':
+                continue
+            elif child.tag == 'filterExecutors':
+                view['filter-executors'] = get_bool(child.tag)
+            elif child.tag == 'filterQueue':
+                view['filter-queue'] = get_bool(child.tag)
+            elif child.tag == 'jobNames':
+                jobs = []
+                for gchild in child:
+                    if gchild.tag == 'string':
+                        jobs.append(gchild.text)
+                view['job-name'] = jobs
+            elif child.tag == 'columns':
+                columns = []
+                for gchild in child:
+                    if gchild.tag in self.COLUMN_DICT:
+                        columns.append(self.COLUMN_DICT[gchild.tag])
+                view['columns'] = columns
+            elif child.tag == 'recurse':
+                view['recurse'] = get_bool(child.tag)
+        yml_parent.update(view)

--- a/jenkins_job_wrecker/registry.py
+++ b/jenkins_job_wrecker/registry.py
@@ -35,7 +35,8 @@ class Registry(object):
                            'matrix-project': 'matrix',
                            'com.cloudbees.plugins.flow.BuildFlow': 'flow',
                            'flow-definition': 'pipeline',
-                           'com.cloudbees.hudson.plugins.folder.Folder': 'folder'}
+                           'com.cloudbees.hudson.plugins.folder.Folder': 'folder',
+                           'hudson.model.ListView': 'listview'}
             for name, item in self._get_entry_points('jenkins_job_wrecker.projects').iteritems():
                 valid_types.update(item)
             self.project_types.update(valid_types)


### PR DESCRIPTION
Here are views. The codebase is definitely made with job configs in mind, so views are kind of the black sheep here. I split jobs and views into their own separate lists and made an inner function to do the loop for converting the list of names to yaml files as to reuse code as much as possible. I tried my best not to destroy the main codebase too much just for views, but anything feels too shoehorned, feel free to ask for changes.

I thought going straight to a Listview object instead of using the Handlers class was probably easiest as you know all of the view elements will be with that one class, but if there is a better way to do that I would rather use that. It seemed weird with the entirety of it only being the view dict and nothing else.

Here is an example of the view XML:
```
<?xml version="1.0" encoding="UTF-8"?>
<hudson.model.ListView>
  <name>test-view</name>
  <filterExecutors>false</filterExecutors>
  <filterQueue>false</filterQueue>
  <properties class="hudson.model.View$PropertyList"/>
  <jobNames>
    <comparator class="hudson.util.CaseInsensitiveComparator"/>
    <string>job1</string>
    <string>job2</string>
    <string>job3</string>
    <string>job4</string>
  </jobNames>
  <jobFilters/>
  <columns>
    <hudson.views.StatusColumn/>
    <hudson.views.WeatherColumn/>
    <hudson.views.JobColumn/>
    <hudson.views.LastSuccessColumn/>
    <hudson.views.LastFailureColumn/>
    <hudson.views.LastDurationColumn/>
    <hudson.views.BuildButtonColumn/>
    <hudson.plugins.favorite.column.FavoriteColumn plugin="favorite@2.3.0"/>
  </columns>
  <recurse>true</recurse>
</hudson.model.ListView>
```