### PR TITLE
Change scriptPath to script-path

### DIFF
--- a/jenkins_job_wrecker/modules/scriptpath.py
+++ b/jenkins_job_wrecker/modules/scriptpath.py
@@ -6,4 +6,4 @@ class Scriptpath(jenkins_job_wrecker.modules.base.Base):
     component = 'scriptpath'
 
     def gen_yml(self, yml_parent, data):
-        yml_parent.append(['scriptPath', data.text])
+        yml_parent.append(['script-path', data.text])


### PR DESCRIPTION
The XML element is named scriptPath, but
the yaml element should be called script-path
for jenkins job builder to correctly use it.