### PR TITLE
Pass in the user specified output directory to convert_to_yml function

### DIFF
--- a/jenkins_job_wrecker/cli.py
+++ b/jenkins_job_wrecker/cli.py
@@ -295,5 +295,5 @@ def main():
                 output_file.write(yaml)
                 output_file.close()
 
-        convert_to_yml(job_names, 'job')
-        convert_to_yml(view_names, 'view', output_dir='output/views')
+        convert_to_yml(job_names, 'job',output_dir=args.output_dir)
+        convert_to_yml(view_names, 'view', output_dir=args.output_dir+"/views")

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ class PyTest(TestCommand):
 
     def run_tests(self):
         import pytest
-        errno = pytest.main('tests', self.pytest_args)
+        errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
 


### PR DESCRIPTION
Fixes #90 

Now -o my_output_folder  is working as expected. 