### PR TITLE
cli.py: use args.output_dir for the output dir.

### DIFF
--- a/jenkins_job_wrecker/cli.py
+++ b/jenkins_job_wrecker/cli.py
@@ -295,5 +295,7 @@ def main():
                 output_file.write(yaml)
                 output_file.close()
 
-        convert_to_yml(job_names, 'job')
-        convert_to_yml(view_names, 'view', output_dir='output/views')
+        convert_to_yml(job_names, 'job', 
+                       output_dir=args.output_dir)
+        convert_to_yml(view_names, 'view',
+                       output_dir=os.path.join(args.output_dir,"views"))


### PR DESCRIPTION
Output was being written to "./output" when "--output-dir" was set.
This uses "args.output_dir".
