### PR TITLE
modules/scm.py: Call 'getchildren()', rather than use '._children'

### DIFF
--- a/jenkins_job_wrecker/modules/scm.py
+++ b/jenkins_job_wrecker/modules/scm.py
@@ -338,7 +338,7 @@ def subversionscm(top, parent):
         elif child.tag == 'locations':
             if len(list(child)) > 0:
                 repos = []
-                for c in child._children:
+                for c in child.getchildren():
                     repo = {}
                     for r in c:
                         if r.tag == 'remote':


### PR DESCRIPTION
"getchildren()" seemed to work.
