### PR TITLE
Groovy Postbuild plugin v2 support

### DIFF
--- a/tests/fixtures/publishers/groovy-postbuild-v2.xml
+++ b/tests/fixtures/publishers/groovy-postbuild-v2.xml
@@ -1,0 +1,8 @@
+    <org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder plugin="groovy-postbuild@2.5">
+      <script plugin="script-security@1.66">
+        <script>foo bar</script>
+        <sandbox>false</sandbox>
+      </script>
+      <behavior>0</behavior>
+      <runForMatrixParent>false</runForMatrixParent>
+    </org.jvnet.hudson.plugins.groovypostbuild.GroovyPostbuildRecorder>

--- a/tests/test_modules_publishers.py
+++ b/tests/test_modules_publishers.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from jenkins_job_wrecker.cli import get_xml_root
+from jenkins_job_wrecker.modules.publishers import groovypostbuildrecorder
+import os
+
+fixtures_path = os.path.join(os.path.dirname(__file__), 'fixtures', 'publishers')
+
+
+class TestGroovyPostbuildPlugin(object):
+    def test_v2(self):
+        filename = os.path.join(fixtures_path, 'groovy-postbuild-v2.xml')
+        root = get_xml_root(filename=filename)
+        assert root is not None
+        parent = []
+        groovypostbuildrecorder(root, parent)
+        assert len(parent) == 1
+        assert 'groovy-postbuild' in parent[0]
+        jjb_groovy_postbuild = parent[0]['groovy-postbuild']
+        assert jjb_groovy_postbuild['matrix-parent'] is False
+        assert jjb_groovy_postbuild['on-failure'] == 'nothing'
+        assert jjb_groovy_postbuild['sandbox'] is False
+        assert jjb_groovy_postbuild['script'] == 'foo bar'


### PR DESCRIPTION
Add support for Groovy Postbuild plugin v2.0+
    
From https://plugins.jenkins.io/groovy-postbuild/:
> From version 2.0, Groovy Postbuild plugin introduces Script Security Plugin.

This change adds support for the markup generated by the plugin in v2.0+.

Also got rid of the useless 'continue' statement which was silently ignoring unknown markup, rather than letting the wrecker convert it into raw XML.