### PR TITLE
Fix CI builds: drop support for Python 3.4 and fix pytest invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
 install:

--- a/setup.py
+++ b/setup.py
@@ -123,7 +123,7 @@ class PyTest(TestCommand):
 
     def run_tests(self):
         import pytest
-        errno = pytest.main('tests', self.pytest_args)
+        errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 
 


### PR DESCRIPTION
This change "fixes" Travis CI failures on current HEAD of master:
- https://travis-ci.com/github/ktdreyer/jenkins-job-wrecker/jobs/334483381

PyYAML used by JJB no longer supports Python 3.4. As it's old enough
folks should migrate to a newer version anyway.