### PR TITLE
run tests with tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.py[cod]
 *.swp
 *.egg-info
+/.tox
 /build
 /dist
 /output

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-install:
- - pip install jenkins-job-builder
-script: python setup.py test
+install: pip install tox-travis
+script: tox
+cache: pip

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ import re
 import subprocess
 import sys
 from setuptools import setup, find_packages, Command
-from setuptools.command.test import test as TestCommand
 try:
     # Python 2 backwards compat
     from __builtin__ import raw_input as input
@@ -109,24 +108,6 @@ class ReleaseCommand(Command):
         subprocess.check_call(cmd)
 
 
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
-
-
 setup(name="jenkins-job-wrecker",
       version=version,
       description=('convert Jenkins XML to YAML'),
@@ -151,13 +132,8 @@ setup(name="jenkins-job-wrecker",
               'jjwrecker = jenkins_job_wrecker.cli:main',
           ],
       },
-      tests_require=[
-          'pytest',
-          'jenkins-job-builder',
-      ],
       cmdclass={
           'bump': BumpCommand,
           'release': ReleaseCommand,
-          'test': PyTest,
       },
      )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+[tox]
+envlist = py27, py35, py36, py37, flake8
+
+[testenv]
+deps=
+  jenkins-job-builder
+  pytest
+  python-jenkins
+  pyyaml
+commands=py.test -v tests
+
+[testenv:flake8]
+deps=flake8
+commands=flake8 --select=F,E9 jenkins_job_wrecker


### PR DESCRIPTION
Run `pytest` within `tox` instead of `setuptools`.

Setuptools' `test` command might be deprecated in the future, and `tox` makes it easier to test multiple Python versions locally.