### PR TITLE
Support for Child custom workspace

### DIFF
--- a/jenkins_job_wrecker/modules/handlers.py
+++ b/jenkins_job_wrecker/modules/handlers.py
@@ -174,6 +174,10 @@ def customworkspace(top, parent):
     parent.append(['workspace', top.text])
 
 
+def childcustomworkspace(top, parent):
+    parent.append(['child-workspace', top.text])
+
+
 def jdk(top, parent):
     parent.append(['jdk', top.text])
 

--- a/tests/fixtures/handlers/child-custom-workspace.xml
+++ b/tests/fixtures/handlers/child-custom-workspace.xml
@@ -1,0 +1,1 @@
+<childCustomWorkspace>lorem</childCustomWorkspace>

--- a/tests/test_modules_handlers.py
+++ b/tests/test_modules_handlers.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from jenkins_job_wrecker.cli import get_xml_root
+from jenkins_job_wrecker.modules.handlers import childcustomworkspace
+import os
+
+fixtures_path = os.path.join(os.path.dirname(__file__), 'fixtures', 'handlers')
+
+
+class TestChildCustomWorkspace(object):
+    def test_basic(self):
+        filename = os.path.join(fixtures_path, 'child-custom-workspace.xml')
+        root = get_xml_root(filename=filename)
+        assert root is not None
+        parent = []
+        childcustomworkspace(root, parent)
+        assert len(parent) == 1
+        assert parent[0][0] == "child-workspace"
+        assert parent[0][1] == "lorem"


### PR DESCRIPTION
Added support child custom workspace which is a parameter from matrix type jobs. Added a test case.