### PR TITLE
Fix copyright formatting in README (again)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,5 +85,5 @@ License
 -------
 MIT (see ``LICENSE``)
 
-Copyright (c) 2015-2020 Red Hat, Inc.\
-Copyright (c) 2020 Liberty Global B.V.
+* Copyright (c) 2015-2020 Red Hat, Inc.
+* Copyright (c) 2020 Liberty Global B.V.


### PR DESCRIPTION
In my previous commit I used Markdown markup, not ReStructuredText (sic!). I've fixed my mistake, but the canonical RST way of doing line breaks (prefixing lines with `|`) apparently [doesn't work on GitHub READMEs](https://gist.github.com/dupuy/1855764#line-blocks-and-hard-line-breaks), so switched to lists in the end.