### PR TITLE
Fix prebuildcleanup returning empty attributes as null

### DIFF
--- a/jenkins_job_wrecker/modules/buildwrappers.py
+++ b/jenkins_job_wrecker/modules/buildwrappers.py
@@ -143,6 +143,8 @@ def prebuildcleanup(top, parent):
     preclean = {}
     preclean_patterns = {'include': '', 'exclude': ''}
     for element in top:
+        if element.text is None:
+            continue
         if element.tag == 'deleteDirs':
             preclean['dirmatch'] = (element.text == 'true')
         elif element.tag == 'patterns':

--- a/tests/fixtures/buildwrappers/prebuildcleanup_empty_value.xml
+++ b/tests/fixtures/buildwrappers/prebuildcleanup_empty_value.xml
@@ -1,0 +1,6 @@
+<hudson.plugins.ws__cleanup.PreBuildCleanup plugin="ws-cleanup@0.37">
+  <deleteDirs>true</deleteDirs>
+  <cleanupParameter></cleanupParameter>
+  <externalDelete></externalDelete>
+  <disableDeferredWipeout>true</disableDeferredWipeout>
+</hudson.plugins.ws__cleanup.PreBuildCleanup>

--- a/tests/test_modules_buildwrappers.py
+++ b/tests/test_modules_buildwrappers.py
@@ -21,3 +21,17 @@ class TestPreBuildCleanup(object):
         assert jjb_ws_cleanup['disable-deferred-wipeout'] is True
         assert jjb_ws_cleanup['check-parameter'] == 'DO_WS_CLEANUP'
         assert jjb_ws_cleanup['external-deletion-command'] == 'shred -u %s'
+
+    def test_empty_value(self):
+        filename = os.path.join(fixtures_path, 'prebuildcleanup_empty_value.xml')
+        root = get_xml_root(filename=filename)
+        assert root is not None
+        parent = []
+        prebuildcleanup(root, parent)
+        assert len(parent) == 1
+        assert 'workspace-cleanup' in parent[0]
+        jjb_ws_cleanup = parent[0]['workspace-cleanup']
+        assert jjb_ws_cleanup['dirmatch'] is True
+        assert jjb_ws_cleanup['disable-deferred-wipeout'] is True
+        assert 'external-deletion-command' not in jjb_ws_cleanup
+        assert 'check-parameter' not in jjb_ws_cleanup


### PR DESCRIPTION
Updated buildwrappers.py to prevent empty attributes on xml converting as `- key: null` and added a new test case for validation.

Validated by @aromanek and @vdanaila