### PR TITLE
fix(typo): fix typo in aws credentials secretbuildwrapper

### DIFF
--- a/jenkins_job_wrecker/modules/buildwrappers.py
+++ b/jenkins_job_wrecker/modules/buildwrappers.py
@@ -224,7 +224,7 @@ def secretbuildwrapper(top, parent):
         elif binding.tag == 'org.jenkinsci.plugins.credentialsbinding.impl.StringBinding':
             bindings.append({'text': params})
         elif binding.tag == 'com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentialsBinding':
-            bindings.append({'amazon-web-services', params})
+            bindings.append({'amazon-web-services': params})
         else:
             raise NotImplementedError("cannot handle XML %s" % binding.tag)
 

--- a/tests/fixtures/buildwrappers/awsbindings.xml
+++ b/tests/fixtures/buildwrappers/awsbindings.xml
@@ -1,0 +1,9 @@
+<org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@1.18">
+    <bindings>
+        <com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentialsBinding plugin="aws-credentials@1.26">
+            <credentialsId>001</credentialsId>
+            <accessKeyVariable>AWS_ACCESS_KEY</accessKeyVariable>
+            <secretKeyVariable>AWS_SECRET_KEY</secretKeyVariable>
+        </com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentialsBinding>
+    </bindings>
+</org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>

--- a/tests/test_modules_buildwrappers.py
+++ b/tests/test_modules_buildwrappers.py
@@ -1,37 +1,54 @@
 # -*- coding: utf-8 -*-
 from jenkins_job_wrecker.cli import get_xml_root
-from jenkins_job_wrecker.modules.buildwrappers import prebuildcleanup
+from jenkins_job_wrecker.modules.buildwrappers import (
+    prebuildcleanup,
+    secretbuildwrapper,
+)
 import os
 
-fixtures_path = os.path.join(os.path.dirname(
-    __file__), 'fixtures', 'buildwrappers')
+fixtures_path = os.path.join(os.path.dirname(__file__), "fixtures", "buildwrappers")
 
 
 class TestPreBuildCleanup(object):
     def test_basic(self):
-        filename = os.path.join(fixtures_path, 'prebuildcleanup.xml')
+        filename = os.path.join(fixtures_path, "prebuildcleanup.xml")
         root = get_xml_root(filename=filename)
         assert root is not None
         parent = []
         prebuildcleanup(root, parent)
         assert len(parent) == 1
-        assert 'workspace-cleanup' in parent[0]
-        jjb_ws_cleanup = parent[0]['workspace-cleanup']
-        assert jjb_ws_cleanup['dirmatch'] is True
-        assert jjb_ws_cleanup['disable-deferred-wipeout'] is True
-        assert jjb_ws_cleanup['check-parameter'] == 'DO_WS_CLEANUP'
-        assert jjb_ws_cleanup['external-deletion-command'] == 'shred -u %s'
+        assert "workspace-cleanup" in parent[0]
+        jjb_ws_cleanup = parent[0]["workspace-cleanup"]
+        assert jjb_ws_cleanup["dirmatch"] is True
+        assert jjb_ws_cleanup["disable-deferred-wipeout"] is True
+        assert jjb_ws_cleanup["check-parameter"] == "DO_WS_CLEANUP"
+        assert jjb_ws_cleanup["external-deletion-command"] == "shred -u %s"
 
     def test_empty_value(self):
-        filename = os.path.join(fixtures_path, 'prebuildcleanup_empty_value.xml')
+        filename = os.path.join(fixtures_path, "prebuildcleanup_empty_value.xml")
         root = get_xml_root(filename=filename)
         assert root is not None
         parent = []
         prebuildcleanup(root, parent)
         assert len(parent) == 1
-        assert 'workspace-cleanup' in parent[0]
-        jjb_ws_cleanup = parent[0]['workspace-cleanup']
-        assert jjb_ws_cleanup['dirmatch'] is True
-        assert jjb_ws_cleanup['disable-deferred-wipeout'] is True
-        assert 'external-deletion-command' not in jjb_ws_cleanup
-        assert 'check-parameter' not in jjb_ws_cleanup
+        assert "workspace-cleanup" in parent[0]
+        jjb_ws_cleanup = parent[0]["workspace-cleanup"]
+        assert jjb_ws_cleanup["dirmatch"] is True
+        assert jjb_ws_cleanup["disable-deferred-wipeout"] is True
+        assert "external-deletion-command" not in jjb_ws_cleanup
+        assert "check-parameter" not in jjb_ws_cleanup
+
+
+class TestAWSBindings(object):
+    def test_aws(self):
+        filename = os.path.join(fixtures_path, "awsbindings.xml")
+        root = get_xml_root(filename=filename)
+        assert root is not None
+        parent = []
+        secretbuildwrapper(root, parent)
+        assert len(parent) == 1
+        assert "credentials-binding" in parent[0]
+        jjb_aws_binding = parent[0]["credentials-binding"][0]["amazon-web-services"]
+        assert jjb_aws_binding["credential-id"] == "001"
+        assert jjb_aws_binding["access-key"] == "AWS_ACCESS_KEY"
+        assert jjb_aws_binding["secret-key"] == "AWS_SECRET_KEY"


### PR DESCRIPTION
Found a typo in how AWS credentials are appended to the list of bindings in the `secretbuildwrapper` function.  Added a test for it as well.  Thanks for putting this together!  It's saving me a ton of headaches converting my Jenkins jobs to JJB!