### PR TITLE
Add support for ssh key wrapper

### DIFF
--- a/jenkins_job_wrecker/modules/buildwrappers.py
+++ b/jenkins_job_wrecker/modules/buildwrappers.py
@@ -225,6 +225,8 @@ def secretbuildwrapper(top, parent):
             bindings.append({'text': params})
         elif binding.tag == 'com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentialsBinding':
             bindings.append({'amazon-web-services': params})
+        elif binding.tag == 'org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding':
+            bindings.append({'ssh-user-private-key': params})
         else:
             raise NotImplementedError("cannot handle XML %s" % binding.tag)
 
@@ -234,13 +236,21 @@ def secretbuildwrapper(top, parent):
             elif child.tag == 'variable':
                 params['variable'] = child.text
             elif child.tag == 'usernameVariable':
-                params['username'] = child.text
+                if binding.tag != 'org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding':
+                    params['username'] = child.text
+                elif child.text is not None:
+                    params['username-variable'] = child.text
             elif child.tag == 'passwordVariable':
                 params['password'] = child.text
             elif child.tag == 'accessKeyVariable':
                 params['access-key'] = child.text
             elif child.tag == 'secretKeyVariable':
                 params['secret-key'] = child.text
+            elif child.tag == 'keyFileVariable':
+                params['key-file-variable'] = child.text
+            elif child.tag == 'passphraseVariable':
+                if child.text is not None:
+                    params['passphrase-variable'] = child.text
             else:
                 raise NotImplementedError("cannot handle XML %s" % binding.tag)
 

--- a/tests/fixtures/buildwrappers/sshkeybindings-no-user-passphrase.xml
+++ b/tests/fixtures/buildwrappers/sshkeybindings-no-user-passphrase.xml
@@ -1,0 +1,10 @@
+<org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@1.24">
+    <bindings>
+        <org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding>
+            <credentialsId>ssh-key-backup</credentialsId>
+            <keyFileVariable>BUILD_KEY</keyFileVariable>
+            <usernameVariable />
+            <passphraseVariable />
+        </org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding>
+    </bindings>
+</org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>

--- a/tests/fixtures/buildwrappers/sshkeybindings-with-user-passphrase.xml
+++ b/tests/fixtures/buildwrappers/sshkeybindings-with-user-passphrase.xml
@@ -1,0 +1,10 @@
+<org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper plugin="credentials-binding@1.24">
+    <bindings>
+        <org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding>
+            <credentialsId>ssh-key-backup</credentialsId>
+            <keyFileVariable>BUILD_KEY</keyFileVariable>
+            <usernameVariable>USERNAME</usernameVariable>
+            <passphraseVariable>PASSPHRASE</passphraseVariable>
+        </org.jenkinsci.plugins.credentialsbinding.impl.SSHUserPrivateKeyBinding>
+    </bindings>
+</org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapper>

--- a/tests/test_modules_buildwrappers.py
+++ b/tests/test_modules_buildwrappers.py
@@ -48,7 +48,36 @@ class TestAWSBindings(object):
         secretbuildwrapper(root, parent)
         assert len(parent) == 1
         assert "credentials-binding" in parent[0]
-        jjb_aws_binding = parent[0]["credentials-binding"][0]["amazon-web-services"]
-        assert jjb_aws_binding["credential-id"] == "001"
-        assert jjb_aws_binding["access-key"] == "AWS_ACCESS_KEY"
-        assert jjb_aws_binding["secret-key"] == "AWS_SECRET_KEY"
+        jjb_binding = parent[0]["credentials-binding"][0]["amazon-web-services"]
+        assert jjb_binding["credential-id"] == "001"
+        assert jjb_binding["access-key"] == "AWS_ACCESS_KEY"
+        assert jjb_binding["secret-key"] == "AWS_SECRET_KEY"
+
+class TestSSHKeyBindings(object):
+    def test_no_user_passphrase(self):
+        filename = os.path.join(fixtures_path, "sshkeybindings-no-user-passphrase.xml")
+        root = get_xml_root(filename=filename)
+        assert root is not None
+        parent = []
+        secretbuildwrapper(root, parent)
+        assert len(parent) == 1
+        assert "credentials-binding" in parent[0]
+        jjb_binding = parent[0]["credentials-binding"][0]["ssh-user-private-key"]
+        assert jjb_binding["credential-id"] == "ssh-key-backup"
+        assert jjb_binding["key-file-variable"] == "BUILD_KEY"
+        assert "username-variable" not in jjb_binding
+        assert "passphrase-variable" not in jjb_binding
+
+    def test_with_user_passphrase(self):
+        filename = os.path.join(fixtures_path, "sshkeybindings-with-user-passphrase.xml")
+        root = get_xml_root(filename=filename)
+        assert root is not None
+        parent = []
+        secretbuildwrapper(root, parent)
+        assert len(parent) == 1
+        assert "credentials-binding" in parent[0]
+        jjb_binding = parent[0]["credentials-binding"][0]["ssh-user-private-key"]
+        assert jjb_binding["credential-id"] == "ssh-key-backup"
+        assert jjb_binding["key-file-variable"] == "BUILD_KEY"
+        assert jjb_binding["username-variable"] == "USERNAME"
+        assert jjb_binding["passphrase-variable"] == "PASSPHRASE"


### PR DESCRIPTION
Based on doc in https://docs.openstack.org/infra/jenkins-job-builder/wrappers.html?highlight=binding#wrappers.credentials-binding, this PR adds the support for `SSHUserPrivateKeyBinding` credential binding.